### PR TITLE
Handle navigateTo "/thing?with=query&and#hash", query: {more: "args"}

### DIFF
--- a/lib/browser/navigation.js
+++ b/lib/browser/navigation.js
@@ -31,23 +31,34 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var NavigationMixin, defaults, hasType, isObject, makeUrlRegExp, omit, qs, ref, urlParse, waitFor;
+var NavigationMixin, defaults, extend, extendUrlWithQuery, hasType, isObject, makeUrlRegExp, omit, pick, qs, ref, ref1, size, urlFormat, urlParse, waitFor;
 
-urlParse = require('url').parse;
+ref = require('url'), urlParse = ref.parse, urlFormat = ref.format;
 
 qs = require('querystring');
 
 hasType = require('assertive').hasType;
 
-ref = require('lodash'), omit = ref.omit, defaults = ref.defaults, isObject = ref.isObject;
+ref1 = require('lodash'), omit = ref1.omit, defaults = ref1.defaults, extend = ref1.extend, isObject = ref1.isObject, pick = ref1.pick, size = ref1.size;
 
 waitFor = require('./wait');
 
 makeUrlRegExp = require('./makeUrlRegExp');
 
+extendUrlWithQuery = function(url, queryArgs) {
+  var parts, query;
+  if (size(queryArgs) === 0) {
+    return url;
+  }
+  parts = urlParse(url);
+  query = extend(qs.parse(parts.query), queryArgs);
+  parts.search = '?' + qs.encode(query);
+  return urlFormat(pick(parts, 'protocol', 'slashes', 'host', 'auth', 'pathname', 'search', 'hash'));
+};
+
 NavigationMixin = {
   navigateTo: function(url, options) {
-    var currentUrl, hasNoProtocol, hasProtocol, query, sep;
+    var currentUrl, hasNoProtocol, hasProtocol, query;
     if (options == null) {
       options = {};
     }
@@ -55,8 +66,7 @@ NavigationMixin = {
     query = options.query;
     if (query != null) {
       hasType('navigateTo(url, {query}) - query must be an Object, if provided', Object, query);
-      sep = /\?/.test(url) ? '&' : '?';
-      url += sep + qs.encode(query);
+      url = extendUrlWithQuery(url, query);
     }
     options = defaults({
       url: url

--- a/test/unit/browser/navigation.test.coffee
+++ b/test/unit/browser/navigation.test.coffee
@@ -10,7 +10,7 @@ describe 'navigation', ->
         post: ->
       refresh: ->
       getUrl: ->
-      navigateTo: ->
+      navigateTo: (url) -> browser.fetched = url
       getCurrentWindowHandle: ->
   navigation = extend browser, NavigationMixin
 
@@ -19,9 +19,25 @@ describe 'navigation', ->
       assert.throws ->
         navigation.navigateTo undefined
 
+    it 'fails if query is not an object', ->
+      assert.throws ->
+        navigation.navigateTo '/anywhere', {query: 'non-object query'}
+
     it 'fails if url is not a String', ->
       assert.throws ->
         navigation.navigateTo noop
 
     it 'suceeds if all conditions are met', ->
       navigation.navigateTo 'http://127.0.0.1:3000'
+
+    it 'composes urls correctly with given query args', ->
+      navigation.navigateTo '/path?x=old#hash', query: {x: 'new', add: 'this'}
+      assert.equal '/path?x=new&add=this#hash', browser.fetched
+
+    it 'retains non-standard url queries', ->
+      navigation.navigateTo '/?query-arg-without-value'
+      assert.equal '/?query-arg-without-value', browser.fetched
+
+    it 'retains the beginning of a url too', ->
+      navigation.navigateTo 'http://www.google.com/', query: q: 'testium'
+      assert.equal 'http://www.google.com/?q=testium', browser.fetched


### PR DESCRIPTION
I just discovered that `browser.navigateTo '/path#hash', query: {some: 'args'}` fails to compose the sought url (it appends query args to the url fragment, instead of splicing them in before it). That's not nice.