### PR TITLE
support node 0.12 and iojs-v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
     - 0.10
+    - 0.12
+    - iojs-v2
+sudo: false

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ system-level libraries.
 - **libcurl** (for sync http)
 <br>[Ubuntu] `sudo apt-get install libcurl4-openssl-dev`
 <br>[OS X] `brew install curl`
-- **Node.js 0.10+**
+- **Node.js 0.10+, 0.12+, 2.0+**
 - **phantomjs 1.9.7+** (only for headless testing)
 - **java 7+** (only when running in browsers)
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "read-package-json": "^1.2.7",
     "selenium-download": "^2.0.0",
     "semver": "^4.1.0",
-    "webdriver-http-sync": "^1.0.0"
+    "webdriver-http-sync": "^1.1.0"
   },
   "devDependencies": {
     "coffee-script": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "coffee-script": "1.9.3",
-    "mocha": "^1.21.5",
+    "mocha": "^2.2.5",
     "node-static": "~0.7.6",
     "npub": "0.0.6",
     "rimraf": "^2.2.8"

--- a/test/missing_selenium.test.coffee
+++ b/test/missing_selenium.test.coffee
@@ -33,5 +33,5 @@ describe 'Missing selenium', ->
         done exitCodeError
 
   it 'mentions useful options', ->
-    assert.include '$ ./node_modules/.bin/testium --download-selenium', @stderr
-    assert.include '[selenium]\njar =', @stderr
+    assert.include '$ ./node_modules/.bin/testium --download-selenium', @stdout
+    assert.include '[selenium]\njar =', @stdout

--- a/test/start_timeout.test.coffee
+++ b/test/start_timeout.test.coffee
@@ -33,11 +33,11 @@ describe 'App startup timeout', ->
 
   it 'mentions helpful details', ->
     try
-      assert.include 'command: coffee', @stderr
-      assert.include 'test/app', @stderr
-      assert.include 'timeout: 250ms', @stderr
-      assert.include 'test/start_timeout_log/application.log', @stderr
-      assert.include '> Refusing to listen', @stderr
+      assert.include 'command: coffee', @stdout
+      assert.include 'test/app', @stdout
+      assert.include 'timeout: 250ms', @stdout
+      assert.include 'test/start_timeout_log/application.log', @stdout
+      assert.include '> Refusing to listen', @stdout
     catch error
       console.log "stdout: #{@stdout}"
       console.log "stderr: #{@stderr}"


### PR DESCRIPTION
Add test support for Node.js 0.12 and iojs-v2.

We can't use iojs-v3 because [http-sync](https://github.com/dhruvbird/http-sync) needs to update [nan](https://github.com/nodejs/nan), but doing that requires code changes that I don't know how to make.

This required an upgrade to mocha, which appears to have switched how it outputs certain things.