### PR TITLE
update npub

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "coffee-script": "1.9.3",
     "mocha": "^1.21.5",
     "node-static": "~0.7.6",
-    "npub": "0.0.6",
+    "npub": "^2.2.0",
     "rimraf": "^2.2.8"
   }
 }


### PR DESCRIPTION
Super old version - when I tried to publish, this is what came up:

```bash
$ npub publish patch
called publish
```

Updating to latest version so I can have a hope of publishing.

@EndangeredMassa, could I get permissions to publish testium?