### PR TITLE
Make tests pass without TTY

### DIFF
--- a/test/integration/element.test.coffee
+++ b/test/integration/element.test.coffee
@@ -1,6 +1,9 @@
 injectBrowser = require '../../mocha'
 assert = require 'assertive'
 
+stripColors = (message) ->
+  message.replace /\u001b\[[^m]*m/g, ''
+
 describe 'element', ->
   before injectBrowser()
 
@@ -32,13 +35,13 @@ describe 'element', ->
   describe 'elementIsVisible', ->
     it 'fails if element does not exist', ->
       error = assert.throws => @browser.assert.elementIsVisible '.non-existing'
-      expectedError = 'Assertion failed: Element not found for selector: .non-existing\n\u001b[39;49;00mExpected \u001b[31mnull\u001b[39m to be truthy'
-      assert.equal expectedError, error.message
+      expectedError = 'Assertion failed: Element not found for selector: .non-existing\nExpected null to be truthy'
+      assert.equal expectedError, stripColors error.message
 
     it 'fails if element exists, but is not visible', ->
       error = assert.throws => @browser.assert.elementIsVisible '#hidden_thing'
-      expectedError = 'Assertion failed: Element should be visible for selector: #hidden_thing\n\u001b[39;49;00mExpected \u001b[31mfalse\u001b[39m to be truthy'
-      assert.equal expectedError, error.message
+      expectedError = 'Assertion failed: Element should be visible for selector: #hidden_thing\nExpected false to be truthy'
+      assert.equal expectedError, stripColors error.message
 
     it 'succeeds if element exists and is visible', ->
       @browser.assert.elementIsVisible 'h1'
@@ -46,13 +49,13 @@ describe 'element', ->
   describe 'elementNotVisible', ->
     it 'fails if element does not exist', ->
       error = assert.throws => @browser.assert.elementNotVisible '.non-existing'
-      expectedError = 'Assertion failed: Element not found for selector: .non-existing\n\u001b[39;49;00mExpected \u001b[31mnull\u001b[39m to be truthy'
-      assert.equal expectedError, error.message
+      expectedError = 'Assertion failed: Element not found for selector: .non-existing\nExpected null to be truthy'
+      assert.equal expectedError, stripColors error.message
 
     it 'fails if element exists, but is visible', ->
       error = assert.throws => @browser.assert.elementNotVisible 'h1'
-      expectedError = 'Assertion failed: Element should not be visible for selector: h1\n\u001b[39;49;00mExpected \u001b[31mtrue\u001b[39m to be falsey'
-      assert.equal expectedError, error.message
+      expectedError = 'Assertion failed: Element should not be visible for selector: h1\nExpected true to be falsey'
+      assert.equal expectedError, stripColors error.message
 
     it 'succeeds if element exists and is not visible', ->
       @browser.assert.elementNotVisible '#hidden_thing'
@@ -60,8 +63,8 @@ describe 'element', ->
   describe 'elementExists', ->
     it 'fails if element does not exist', ->
       error = assert.throws => @browser.assert.elementExists '.non-existing'
-      expectedError = 'Assertion failed: Element not found for selector: .non-existing\n\u001b[39;49;00mExpected \u001b[31mnull\u001b[39m to be truthy'
-      assert.equal expectedError, error.message
+      expectedError = 'Assertion failed: Element not found for selector: .non-existing\nExpected null to be truthy'
+      assert.equal expectedError, stripColors error.message
 
     it 'succeeds if element exists', ->
       @browser.assert.elementExists 'h1'
@@ -72,8 +75,8 @@ describe 'element', ->
 
     it 'fails if element exists', ->
       error = assert.throws => @browser.assert.elementDoesntExist 'h1'
-      expectedError = 'Assertion failed: Element found for selector: h1\n\u001b[39;49;00mExpected \u001b[31mElement\u001b[39m to be falsey'
-      assert.equal expectedError, error.message
+      expectedError = 'Assertion failed: Element found for selector: h1\nExpected Element to be falsey'
+      assert.equal expectedError, stripColors error.message
 
   describe 'elementHasText', ->
     it 'finds and returns a single element', ->
@@ -84,8 +87,8 @@ describe 'element', ->
       error = assert.throws =>
         @browser.assert.elementHasText('.only', 'the wrong text')
 
-      expected = 'Assertion failed: elementHasText: .only\n\u001b[39;49;00minclude expected needle to be found in haystack\n- needle: \"the wrong text\"\nhaystack: \"only one here\"'
-      assert.equal expected, error.message
+      expected = 'Assertion failed: elementHasText: .only\ninclude expected needle to be found in haystack\n- needle: \"the wrong text\"\nhaystack: \"only one here\"'
+      assert.equal expected, stripColors error.message
 
     it 'finds no elements', ->
       error = assert.throws =>
@@ -111,8 +114,8 @@ describe 'element', ->
       error = assert.throws =>
         @browser.assert.elementLacksText('.only', 'only')
 
-      expected = 'Assertion failed: elementLacksText: .only\n\u001b[39;49;00mnotInclude expected needle not to be found in haystack\n- needle: \"only\"\nhaystack: \"only one here\"'
-      assert.equal expected, error.message
+      expected = 'Assertion failed: elementLacksText: .only\nnotInclude expected needle not to be found in haystack\n- needle: \"only\"\nhaystack: \"only one here\"'
+      assert.equal expected, stripColors error.message
 
   describe 'elementHasValue', ->
     it 'finds and returns a single element', ->
@@ -131,8 +134,8 @@ describe 'element', ->
       error = assert.throws =>
         @browser.assert.elementLacksValue('#text-input', 'initialvalue')
 
-      expected = 'Assertion failed: elementLacksValue: #text-input\n\u001b[39;49;00mnotInclude expected needle not to be found in haystack\n- needle: \"initialvalue\"\nhaystack: \"initialvalue\"'
-      assert.equal expected, error.message
+      expected = 'Assertion failed: elementLacksValue: #text-input\nnotInclude expected needle not to be found in haystack\n- needle: \"initialvalue\"\nhaystack: \"initialvalue\"'
+      assert.equal expected, stripColors error.message
 
   describe 'waitForElementExist', ->
     before ->


### PR DESCRIPTION
Right now `mocha test/integration` passes but `mocha test/integration | cat` doesn't. Which prevents `npub` from running.