### PR TITLE
Add publishConfig.registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "email": "endangeredmassa@gmail.com"
   },
   "publishConfig": {
+    "registry": "https://registry.npmjs.org",
     "license": {
       "exclude": [
         "cli.js",


### PR DESCRIPTION
This prevents accidental publishes to the wrong destination for people using a `registry` option in their `.npmrc`.